### PR TITLE
Update moment calls (add|subtract)

### DIFF
--- a/lib/bodyView.js
+++ b/lib/bodyView.js
@@ -11,8 +11,8 @@ module.exports = function (selectedMonth, selectedDate) {
     }
 
     var now = parseInt(moment().format('YYYYMMDD'), 10),
-        previousMoment = selectedMonth.clone().subtract('months', 1),
-        nextMoment = selectedMonth.clone().add('months', 1);
+        previousMoment = selectedMonth.clone().subtract(1, 'months'),
+        nextMoment = selectedMonth.clone().add(1, 'months');
 
     var daysInCurrentMonth = selectedMonth.daysInMonth(),
         daysInPreviousMonth = previousMoment.daysInMonth(),

--- a/lib/datepickerView.js
+++ b/lib/datepickerView.js
@@ -20,19 +20,19 @@ module.exports = function (options) {
     var api = {
         el: el,
         incrementYear: function () {
-            selectedMonth.add('years', 1);
+            selectedMonth.add(1, 'years');
             refreshView();
         },
         incrementMonth: function () {
-            selectedMonth.add('months', 1);
+            selectedMonth.add(1, 'months');
             refreshView();
         },
         decrementYear: function () {
-            selectedMonth.subtract('years', 1);
+            selectedMonth.subtract(1, 'years');
             refreshView();
         },
         decrementMonth: function () {
-            selectedMonth.subtract('months', 1);
+            selectedMonth.subtract(1, 'months');
             refreshView();
         }
     };


### PR DESCRIPTION
Use the updated signatures for moment().add(Number, String) and
moment().subtract(Number, String) in favor of the deprecated syntax.

http://momentjs.com/docs/#/manipulating/add/
http://momentjs.com/docs/#/manipulating/subtract/
